### PR TITLE
Fix missing brackets for RedHat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   yum:
     pkg: "{{item}}"
     state: present
-  with_items: perl_packages
+  with_items: "{{ perl_packages }}"
   when: ansible_os_family == "RedHat"
 
 - name: Perl | CPAN | Get the cpan script


### PR DESCRIPTION
Line 21 was missing {{ }} for substitution variable of perl_packages which leads to playbook error for RedHat/CentOS